### PR TITLE
fix: 식품영양성분 조회 API의 응답형식 수정[#102]

### DIFF
--- a/backend/src/main/java/food/backend/search/controller/FoodController.java
+++ b/backend/src/main/java/food/backend/search/controller/FoodController.java
@@ -1,5 +1,6 @@
 package food.backend.search.controller;
 
+import food.backend.search.dto.FoodDetailDTO;
 import food.backend.search.dto.FoodListDTO;
 import food.backend.search.dto.RelatedFoodDto;
 import food.backend.search.service.FoodSearchService;
@@ -27,7 +28,7 @@ public class FoodController {
     }
 
     @GetMapping("/detail")
-    public List<Map<String, Object>> getFoodDetail(@RequestParam Long foodId) {
+    public FoodDetailDTO getFoodDetail(@RequestParam Long foodId) {
         return foodSearchService.getFoodDetailById(foodId);
     }
 

--- a/backend/src/main/java/food/backend/search/dao/FoodDetailDAO.java
+++ b/backend/src/main/java/food/backend/search/dao/FoodDetailDAO.java
@@ -1,7 +1,9 @@
 package food.backend.search.dao;
 
+import food.backend.search.dto.FoodDetailDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -13,9 +15,43 @@ public class FoodDetailDAO {
 
     private final JdbcTemplate jdbcTemplate;
 
-    public List<Map<String, Object>> getFoodDataById(Long foodId) {
+    public FoodDetailDTO getFoodDataById(Long foodId) {
         String sql = "SELECT * FROM food_main WHERE food_id = ?";
-        return jdbcTemplate.queryForList(sql, foodId);
+        return jdbcTemplate.queryForObject(sql, foodRowMapper(), foodId);
     }
 
-}
+    private RowMapper<FoodDetailDTO> foodRowMapper() {
+        return (rs, rowNum) ->
+            FoodDetailDTO.builder()
+                    .foodId(rs.getLong("food_id"))
+                    .foodCd(rs.getString("food_code"))
+                    .foodNm(rs.getString("food_name"))
+                    .enerc(rs.getDouble("enerc"))
+                    .water(rs.getDouble("water"))
+                    .prot(rs.getDouble("prot"))
+                    .fatce(rs.getDouble("fatce"))
+                    .ash(rs.getDouble("ash"))
+                    .chocdf(rs.getDouble("chocdf"))
+                    .sugar(rs.getDouble("sugar"))
+                    .fibtg(rs.getDouble("fibtg"))
+                    .ca(rs.getDouble("ca"))
+                    .fe(rs.getDouble("fe"))
+                    .p(rs.getDouble("p"))
+                    .k(rs.getDouble("k"))
+                    .nat(rs.getDouble("nat"))
+                    .vitaRae(rs.getDouble("vita_rae"))
+                    .retol(rs.getDouble("retol"))
+                    .cartb(rs.getDouble("cartb"))
+                    .thia(rs.getDouble("thia"))
+                    .ribf(rs.getDouble("ribf"))
+                    .nia(rs.getDouble("nia"))
+                    .vitc(rs.getDouble("vitc"))
+                    .vitd(rs.getDouble("vitd"))
+                    .chole(rs.getDouble("chole"))
+                    .fasat(rs.getDouble("fasat"))
+                    .fatrn(rs.getDouble("fatrn"))
+                    .foodSize(rs.getString("food_size"))
+                    .companyName(rs.getString("company_name"))
+                    .build();
+        }
+    }

--- a/backend/src/main/java/food/backend/search/dto/FoodDetailDTO.java
+++ b/backend/src/main/java/food/backend/search/dto/FoodDetailDTO.java
@@ -1,38 +1,41 @@
-//package food.backend.search.dto;
-//
-//import lombok.Builder;
-//
-//@Builder
-//public class FoodInfoDTO {
-//    private String foodCd;
-//    private String foodNm;
-//    private int enerc;
+package food.backend.search.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+public class FoodDetailDTO {
+    private Long foodId;
+    private String foodCd;
+    private String foodNm;
+    private double enerc;
 //    private String nutConSrtrQua;
-//    private double water;
-//    private double prot;
-//    private double fatce;
-//    private double ash;
-//    private double chocdf;
-//    private double sugar;
-//    private double fibtg;
-//    private double ca;
-//    private double fe;
-//    private double p;
-//    private double k;
-//    private double nat;
-//    private double vitaRae;
-//    private double retol;
-//    private double cartb;
-//    private double thia;
-//    private double ribf;
-//    private double nia;
-//    private double vitc;
-//    private double vitd;
-//    private double chole;
-//    private double fasat;
-//    private double fatrn;
+    private double water;
+    private double prot;
+    private double fatce;
+    private double ash;
+    private double chocdf;
+    private double sugar;
+    private double fibtg;
+    private double ca;
+    private double fe;
+    private double p;
+    private double k;
+    private double nat;
+    private double vitaRae;
+    private double retol;
+    private double cartb;
+    private double thia;
+    private double ribf;
+    private double nia;
+    private double vitc;
+    private double vitd;
+    private double chole;
+    private double fasat;
+    private double fatrn;
 //    private double refuse;
-//    private String foodSize;
+    private String foodSize;
 //    private String cooName;
-//    private String companyName;
-//}
+    private String companyName;
+}

--- a/backend/src/main/java/food/backend/search/service/FoodSearchService.java
+++ b/backend/src/main/java/food/backend/search/service/FoodSearchService.java
@@ -2,6 +2,7 @@ package food.backend.search.service;
 
 import food.backend.search.dao.FoodDetailDAO;
 import food.backend.search.dao.FoodListDAO;
+import food.backend.search.dto.FoodDetailDTO;
 import food.backend.search.dto.FoodListDTO;
 import food.backend.search.dto.RelatedFoodDto;
 import food.backend.search.dao.FoodKeywordDAO;
@@ -27,7 +28,7 @@ public class FoodSearchService {
 
     }
 
-    public List<Map<String, Object>> getFoodDetailById(Long foodId) {
+    public FoodDetailDTO getFoodDetailById(Long foodId) {
         return foodDetailDAO.getFoodDataById(foodId);
     }
 


### PR DESCRIPTION
## ✨ PR 내용
- 식품 영양성분 조회결과 형식을 통일하기 위해 queryForList 메서드 대신 queryForObject 메서드를 사용
## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 PR이면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- 컬럼이 여러개인 경우 queryForObject를 사용하면 rowMapper를 이용해 모든 컬럼을 하나하나 매핑해줘야함
- 우리가 사용하는 테이블의 컬럼 수가 30개 이상인데 이를 모두 수동으로 매핑해줘야하는 붎편함이 있음
- 그래서 현재 응답에는 실제로 노출될만한 데이터만 매핑해주었음
## 📌 관련 이슈
fix #102  
