### PR TITLE
fix: 클라이언트 API 테스트 시 발생한 오류 수정[#144]

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -5,7 +5,6 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 .DS_Store
-application.yml
 
 ### STS ###
 .apt_generated

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/backend/src/main/java/food/backend/search/WebConfig.java
+++ b/backend/src/main/java/food/backend/search/WebConfig.java
@@ -1,0 +1,14 @@
+package food.backend.search;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:3000", "http://localhost:8080")
+                .maxAge(3000);
+    }
+}

--- a/backend/src/main/java/food/backend/search/controller/FoodController.java
+++ b/backend/src/main/java/food/backend/search/controller/FoodController.java
@@ -1,5 +1,6 @@
 package food.backend.search.controller;
 
+import food.backend.search.dto.FoodDetailDTO;
 import food.backend.search.dto.FoodListDTO;
 import food.backend.search.dto.RelatedFoodDto;
 import food.backend.search.service.FoodSearchService;
@@ -27,7 +28,7 @@ public class FoodController {
     }
 
     @GetMapping("/detail")
-    public List<Map<String, Object>> getFoodDetail(@RequestParam Long foodId) {
+    public FoodDetailDTO getFoodDetail(@RequestParam Long foodId) {
         return foodSearchService.getFoodDetailById(foodId);
     }
 

--- a/backend/src/main/java/food/backend/search/controller/FoodController.java
+++ b/backend/src/main/java/food/backend/search/controller/FoodController.java
@@ -2,13 +2,13 @@ package food.backend.search.controller;
 
 import food.backend.search.dto.FoodDetailDTO;
 import food.backend.search.dto.FoodListDTO;
-import food.backend.search.dto.RelatedFoodDto;
+import food.backend.search.model.KeywordAndNutrient;
 import food.backend.search.service.FoodSearchService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.Map;
 
 @RestController
 @RequestMapping("/foods/search")
@@ -23,7 +23,7 @@ public class FoodController {
     }
 
     @GetMapping
-    public List<FoodListDTO> getFoodListByNameContaining(@RequestParam Map<String, String> params) {
+    public List<FoodListDTO> searchFoodListByNutrient(@Validated @ModelAttribute KeywordAndNutrient params) {
         return foodSearchService.getFoodListByNameContaining(params);
     }
 

--- a/backend/src/main/java/food/backend/search/dao/FoodDetailDAO.java
+++ b/backend/src/main/java/food/backend/search/dao/FoodDetailDAO.java
@@ -1,7 +1,9 @@
 package food.backend.search.dao;
 
+import food.backend.search.dto.FoodDetailDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -13,9 +15,43 @@ public class FoodDetailDAO {
 
     private final JdbcTemplate jdbcTemplate;
 
-    public List<Map<String, Object>> getFoodDataById(Long foodId) {
+    public FoodDetailDTO getFoodDataById(Long foodId) {
         String sql = "SELECT * FROM food_main WHERE food_id = ?";
-        return jdbcTemplate.queryForList(sql, foodId);
+        return jdbcTemplate.queryForObject(sql, foodRowMapper(), foodId);
     }
 
-}
+    private RowMapper<FoodDetailDTO> foodRowMapper() {
+        return (rs, rowNum) ->
+            FoodDetailDTO.builder()
+                    .foodId(rs.getLong("food_id"))
+                    .foodCd(rs.getString("food_code"))
+                    .foodNm(rs.getString("food_name"))
+                    .enerc(rs.getDouble("enerc"))
+                    .water(rs.getDouble("water"))
+                    .prot(rs.getDouble("prot"))
+                    .fatce(rs.getDouble("fatce"))
+                    .ash(rs.getDouble("ash"))
+                    .chocdf(rs.getDouble("chocdf"))
+                    .sugar(rs.getDouble("sugar"))
+                    .fibtg(rs.getDouble("fibtg"))
+                    .ca(rs.getDouble("ca"))
+                    .fe(rs.getDouble("fe"))
+                    .p(rs.getDouble("p"))
+                    .k(rs.getDouble("k"))
+                    .nat(rs.getDouble("nat"))
+                    .vitaRae(rs.getDouble("vita_rae"))
+                    .retol(rs.getDouble("retol"))
+                    .cartb(rs.getDouble("cartb"))
+                    .thia(rs.getDouble("thia"))
+                    .ribf(rs.getDouble("ribf"))
+                    .nia(rs.getDouble("nia"))
+                    .vitc(rs.getDouble("vitc"))
+                    .vitd(rs.getDouble("vitd"))
+                    .chole(rs.getDouble("chole"))
+                    .fasat(rs.getDouble("fasat"))
+                    .fatrn(rs.getDouble("fatrn"))
+                    .foodSize(rs.getString("food_size"))
+                    .companyName(rs.getString("company_name"))
+                    .build();
+        }
+    }

--- a/backend/src/main/java/food/backend/search/dao/FoodListDAO.java
+++ b/backend/src/main/java/food/backend/search/dao/FoodListDAO.java
@@ -1,6 +1,7 @@
 package food.backend.search.dao;
 
 import food.backend.search.dto.FoodListDTO;
+import food.backend.search.model.KeywordAndNutrient;
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -9,7 +10,6 @@ import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
 
 import java.util.List;
-import java.util.Map;
 
 @Repository
 @RequiredArgsConstructor
@@ -17,72 +17,67 @@ public class FoodListDAO {
 
     private final NamedParameterJdbcTemplate jdbcTemplate;
 
-    public List<FoodListDTO> getFoodListByNameContaining(Map<String, String> params) {
+    public List<FoodListDTO> getFoodListByNameContaining(KeywordAndNutrient params) {
         String sql = "SELECT food_id, food_name, company_name FROM food_main WHERE 1=1";
 
         MapSqlParameterSource paramMap = new MapSqlParameterSource()
-                .addValue("food_name", "%" + params.get("keyword") + "%")
-                .addValue("enerc", params.get("kcal"))
-                .addValue("enerc_con", params.get("kcal_con")) //없는 컬럼
-                .addValue("chocdf", params.get("carb"))
-                .addValue("chocdf_con", params.get("carb_con")) //없는 컬럼
-                .addValue("prot", params.get("prot"))
-                .addValue("prot_con", params.get("prot_con")) //없는 컬럼
-                .addValue("fatce", params.get("fat"))
-                .addValue("fatce_con", params.get("fat_con")); //없는 컬럼
+                .addValue("food_name", "%" + params.getKeyword() + "%")
+                .addValue("enerc", params.getEnerc())
+                .addValue("chocdf", params.getChocdf())
+                .addValue("prot", params.getProt())
+                .addValue("fatce", params.getFatce());
 
-        if (StringUtils.hasText(params.get("keyword"))) {
+        if (StringUtils.hasText(params.getKeyword())) {
             sql += " AND food_name LIKE :food_name";
         }
 
-        if (StringUtils.hasText(params.get("kcal"))) {
+        if (StringUtils.hasText(params.getEnerc())) {
             sql += " AND enerc";
         }
 
-        if (StringUtils.hasText(params.get("kcal_con"))) {
-            if (params.get("kcal_con").equals("1")) {
+        if (StringUtils.hasText(params.getEnercCon())) {
+            if (params.getEnercCon().equals("1")) {
                 sql += " >= :enerc";
             } else {
                 sql += " <= :enerc";
             }
         }
 
-        if (StringUtils.hasText(params.get("carb"))) {
+        if (StringUtils.hasText(params.getChocdf())) {
             sql += " AND chocdf";
         }
 
-        if (StringUtils.hasText(params.get("carb_con"))) {
-            if (params.get("carb_con").equals("1")) {
+        if (StringUtils.hasText(params.getChocdfCon())) {
+            if (params.getChocdfCon().equals("1")) {
                 sql += " >= :chocdf";
             } else {
                 sql += " <= :chocdf";
             }
         }
 
-        if (StringUtils.hasText(params.get("prot"))) {
+        if (StringUtils.hasText(params.getProt())) {
             sql += " AND prot";
         }
 
-        if (StringUtils.hasText(params.get("prot_con"))) {
-            if (params.get("prot_con").equals("1")) {
+        if (StringUtils.hasText(params.getProtCon())) {
+            if (params.getProtCon().equals("1")) {
                 sql += " >= :prot";
             } else {
                 sql += " <= :prot";
             }
         }
 
-        if (StringUtils.hasText(params.get("fat"))) {
+        if (StringUtils.hasText(params.getFatce())) {
             sql += " AND fatce";
         }
 
-        if (StringUtils.hasText(params.get("fat_con"))) {
-            if (params.get("fat_con").equals("1")) {
+        if (StringUtils.hasText(params.getFatceCon())) {
+            if (params.getFatceCon().equals("1")) {
                 sql += " >= :fatce";
             } else {
                 sql += " <= :fatce";
             }
         }
-
         return jdbcTemplate.query(sql, paramMap, foodRowMapper());
     }
 

--- a/backend/src/main/java/food/backend/search/dto/FoodDetailDTO.java
+++ b/backend/src/main/java/food/backend/search/dto/FoodDetailDTO.java
@@ -1,38 +1,41 @@
-//package food.backend.search.dto;
-//
-//import lombok.Builder;
-//
-//@Builder
-//public class FoodInfoDTO {
-//    private String foodCd;
-//    private String foodNm;
-//    private int enerc;
+package food.backend.search.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+public class FoodDetailDTO {
+    private Long foodId;
+    private String foodCd;
+    private String foodNm;
+    private double enerc;
 //    private String nutConSrtrQua;
-//    private double water;
-//    private double prot;
-//    private double fatce;
-//    private double ash;
-//    private double chocdf;
-//    private double sugar;
-//    private double fibtg;
-//    private double ca;
-//    private double fe;
-//    private double p;
-//    private double k;
-//    private double nat;
-//    private double vitaRae;
-//    private double retol;
-//    private double cartb;
-//    private double thia;
-//    private double ribf;
-//    private double nia;
-//    private double vitc;
-//    private double vitd;
-//    private double chole;
-//    private double fasat;
-//    private double fatrn;
+    private double water;
+    private double prot;
+    private double fatce;
+    private double ash;
+    private double chocdf;
+    private double sugar;
+    private double fibtg;
+    private double ca;
+    private double fe;
+    private double p;
+    private double k;
+    private double nat;
+    private double vitaRae;
+    private double retol;
+    private double cartb;
+    private double thia;
+    private double ribf;
+    private double nia;
+    private double vitc;
+    private double vitd;
+    private double chole;
+    private double fasat;
+    private double fatrn;
 //    private double refuse;
-//    private String foodSize;
+    private String foodSize;
 //    private String cooName;
-//    private String companyName;
-//}
+    private String companyName;
+}

--- a/backend/src/main/java/food/backend/search/model/KeywordAndNutrient.java
+++ b/backend/src/main/java/food/backend/search/model/KeywordAndNutrient.java
@@ -1,0 +1,28 @@
+package food.backend.search.model;
+
+import lombok.Data;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+@Data
+public class KeywordAndNutrient {
+
+    @NotNull @NotBlank
+    private String keyword;
+    private String enerc;
+    private String enercCon;
+    private String chocdf;
+    private String chocdfCon;
+    private String prot;
+    private String protCon;
+    private String fatce;
+    private String fatceCon;
+
+    public KeywordAndNutrient(String enerc_con, String chocdf_con, String prot_con, String fatce_con) {
+        this.enercCon = enerc_con;
+        this.chocdfCon = chocdf_con;
+        this.protCon = prot_con;
+        this.fatceCon = fatce_con;
+    }
+}

--- a/backend/src/main/java/food/backend/search/service/FoodSearchService.java
+++ b/backend/src/main/java/food/backend/search/service/FoodSearchService.java
@@ -2,6 +2,7 @@ package food.backend.search.service;
 
 import food.backend.search.dao.FoodDetailDAO;
 import food.backend.search.dao.FoodListDAO;
+import food.backend.search.dto.FoodDetailDTO;
 import food.backend.search.dto.FoodListDTO;
 import food.backend.search.dto.RelatedFoodDto;
 import food.backend.search.dao.FoodKeywordDAO;
@@ -27,7 +28,7 @@ public class FoodSearchService {
 
     }
 
-    public List<Map<String, Object>> getFoodDetailById(Long foodId) {
+    public FoodDetailDTO getFoodDetailById(Long foodId) {
         return foodDetailDAO.getFoodDataById(foodId);
     }
 

--- a/backend/src/main/java/food/backend/search/service/FoodSearchService.java
+++ b/backend/src/main/java/food/backend/search/service/FoodSearchService.java
@@ -4,7 +4,7 @@ import food.backend.search.dao.FoodDetailDAO;
 import food.backend.search.dao.FoodListDAO;
 import food.backend.search.dto.FoodDetailDTO;
 import food.backend.search.dto.FoodListDTO;
-import food.backend.search.dto.RelatedFoodDto;
+import food.backend.search.model.KeywordAndNutrient;
 import food.backend.search.dao.FoodKeywordDAO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -23,7 +23,7 @@ public class FoodSearchService {
         return foodKeywordDAO.getFoodByNameContaining(keyword);
     }
 
-    public List<FoodListDTO> getFoodListByNameContaining(Map<String, String> params) {
+    public List<FoodListDTO> getFoodListByNameContaining(KeywordAndNutrient params) {
         return foodListDAO.getFoodListByNameContaining(params);
 
     }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,1 +1,27 @@
+spring:
+  h2:
+    console:
+      enabled: true
 
+  datasource:
+    # url: jdbc:mysql://seektam-test.cmzzaiee3lj2.ap-northeast-2.rds.amazonaws.com:3306/seektam-test?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    url: jdbc:mysql://database-1.cvrkyws2tbvq.ap-northeast-2.rds.amazonaws.com:3306/seektamDB?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: white
+    password: tnsqor1!
+
+
+  jpa:
+    hibernate:
+
+      ddl-auto: none
+    properties:
+      hibernate:
+        format_sql: true
+
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+    org.hibernate.type: trace


### PR DESCRIPTION
## ✨ PR 내용
- foods/search로 식품리스트 API 조회 시 모든 테이블이 출력되는 오류 수정
- 기존에 식품리스트 API 요청파라미터를 Map객체를 생성해 받던 것을 KeywordAndNutrient 객체를 통해 전달받도록 수정
- keyword 입력값이 없거나 공백일 시 오류처리(@Notnull, @NotBlank) 
## 📸 스크린샷(선택)
- keyword 파라미터가 없는 경우
![image](https://github.com/SWM-snowWhite/SeekTam/assets/108510951/e0098120-fb0e-4419-93a1-2748127913e7)

- keyword 파라미터가 공백인 경우
![image](https://github.com/SWM-snowWhite/SeekTam/assets/108510951/e766825a-c9da-4c1f-863d-65472bff9555)

- foods/search로 조회한 경우
![image](https://github.com/SWM-snowWhite/SeekTam/assets/108510951/74fb96a4-30c4-4131-b4b3-9ab752ae7bcf)


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- 현재 파라미터로 값을 저장할 때 모두 String으로 바인딩하고 있는데 영양성분 같은 경우 어떻게 할지 상의가 필요
- 영양성분 DB의 컬럼명을 전반적으로 손보기 전까지는 API 요청 파라미터명도 DB 컬럼명과 통일하는 것이 좋을듯 ex)kcal -> enerc
- 현재 API는 모두 컬럼명과 맞춰서 사용함
## 📌 관련 이슈
fix #144 
