### PR TITLE
fix: SQL 문법 오류로 인한 배치 프로세스 작동 에러 해결

### DIFF
--- a/backend/src/main/java/food/backend/batch/service/StoreFoodDataService.java
+++ b/backend/src/main/java/food/backend/batch/service/StoreFoodDataService.java
@@ -32,8 +32,8 @@ public class StoreFoodDataService {
     public void saveFoodDataToDatabase(FoodNutritionDto foodData) {
         BeanPropertySqlParameterSource param = new BeanPropertySqlParameterSource(foodData);
         String sql =
-                "INSERT INTO food_main (food_code, food_name, data_code, data_type_name, enerc, nut_con_srtr_qua, water, prot, fatce, ash, chocdf, sugar, fibtg, ca, fe, p, k, nat, vita_rae, retol, cartb, thia, ribf, nia, vitc, vitd, chole, fasat, fatrn, refuse, src_code, src_name, food_size, impt_yn, coo_code, coo_name, company_name, data_prod_code, data_prod_name, crt_ymd, crtr_ymd, instt_code, update_date) " +
-                        "VALUES (:foodCd, :foodNm, :dataCd, :typeNm, :enerc, :nutConSrtrQua, :water, :prot, :fatce, :ash, :chocdf, :sugar, :fibtg, :ca, :fe, :p, :k, :nat, :vitaRae, :retol, :cartb, :thia, :ribf, :nia, :vitc, :vitd, :chole, :fasat, :fatrn, :refuse, :srcCd, :srcNm, :foodSize, :imptYn, :cooCd, :cooNm, :companyNm, :dataProdCd, :dataProdNm, :crtYmd, :crtrYmd, :insttCode, :updateDate) " +
+                "INSERT INTO food_main (food_code, food_name, data_code, data_type_name, enerc, nut_con_srtr_qua, water, prot, fatce, ash, chocdf, sugar, fibtg, ca, fe, p, k, nat, vita_rae, retol, cartb, thia, ribf, nia, vitc, vitd, chole, fasat, fatrn, refuse, src_code, src_name, food_size, impt_yn, coo_code, coo_name, company_name, data_prod_code, data_prod_name, crt_ymd, crtr_ymd, instt_code) " +
+                        "VALUES (:foodCd, :foodNm, :dataCd, :typeNm, :enerc, :nutConSrtrQua, :water, :prot, :fatce, :ash, :chocdf, :sugar, :fibtg, :ca, :fe, :p, :k, :nat, :vitaRae, :retol, :cartb, :thia, :ribf, :nia, :vitc, :vitd, :chole, :fasat, :fatrn, :refuse, :srcCd, :srcNm, :foodSize, :imptYn, :cooCd, :cooNm, :companyNm, :dataProdCd, :dataProdNm, :crtYmd, :crtrYmd, :insttCode) " +
                         "ON DUPLICATE KEY UPDATE " +
                         "food_name = :foodNm, " +
                         "data_code = :dataCd, " +
@@ -75,8 +75,7 @@ public class StoreFoodDataService {
                         "data_prod_name = :dataProdNm, " +
                         "crt_ymd = :crtYmd, " +
                         "crtr_ymd = :crtrYmd, " +
-                        "instt_code = :insttCode, " +
-                        "update_date = :updateDate";
+                        "instt_code = :insttCode ";
 
         jdbcTemplate.update(sql, param);
     }


### PR DESCRIPTION
## ✨ PR 내용
- 기존에는 배치를 활용한 업데이트 시 업데이트 일자를 Dto에 기록 후 MySQL에 함께 업데이트하는 방식 사용
- MySQL의 update_date 컬럼에 Auto Increment를 적용하는 방식으로 변경
- 이에 따른 SQL 쿼리도 수정함으로써 에러 해결

## 🗒️ 코드 설명

## 📸 스크린샷(선택)

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

## 📌 관련 이슈
closes #216 
