### PR TITLE
fix: elasticsearch 클라이언트 생성 후 close되지 않아 최대 connection을 넘기는 문제 수정

### DIFF
--- a/backend/src/main/java/food/backend/search/dao/ProductDao.java
+++ b/backend/src/main/java/food/backend/search/dao/ProductDao.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.RangeQueryBuilder;
@@ -158,8 +159,10 @@ public class ProductDao {
      */
     private SearchResponse getResponse(SearchRequest searchRequest) {
         SearchResponse searchResponse = null;
+        RestHighLevelClient client = elasticsearchConfig.client();
         try {
-            searchResponse = elasticsearchConfig.client().search(searchRequest, RequestOptions.DEFAULT);
+            searchResponse = client.search(searchRequest, RequestOptions.DEFAULT);
+            client.close();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/backend/src/main/java/food/backend/search/dao/ProductKeywordDao.java
+++ b/backend/src/main/java/food/backend/search/dao/ProductKeywordDao.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
@@ -85,10 +86,11 @@ public class ProductKeywordDao {
     private SearchResponse getResponse(SearchRequest searchRequest) {
         // ES 요청 후 결과를 담을 객체 생성
         SearchResponse searchResponse = null;
+        RestHighLevelClient client = elasticsearchConfig.client();
         try {
             // ES 요청 후 결과를 저장
-            searchResponse = elasticsearchConfig.client().search(searchRequest, RequestOptions.DEFAULT);
-            System.out.println("searchResponse = " + searchResponse);
+            searchResponse = client.search(searchRequest, RequestOptions.DEFAULT);
+            client.close();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
## ✨ PR 내용
- elasticsearch를 이용한 API 조회 시, 각 dao 클래스에서 커넥션을 생성하는데, 조회 완료 후 커넥션을 닫지 않아 최대 커넥션 개수를 초과하는 문제 발생
- 해당 문제로 API 조회가 작동하지 않음
- close() 명령어로 조회 완료 후 커넥션 종료하도록 수정

## 🗒️ 코드 설명
<!-- 작성한 코드의 흐름을 간략하게 적어주세요 -->

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 PR이면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->

## 📌 관련 이슈
close #220 
